### PR TITLE
Docs: Fix incorrect theme slug in README (wprog-support → wporg-support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can get involved in development (or any other aspect of the project) by atte
 
 ## How to use this repo
 
-To use this repo, simply create a new WordPress site on your local machine (using whatever development environment suits you), then empty out the `wp-content` folder and clone this repo into it. After logging in to the admin area activate `wprog-support` theme for the site to work.
+To use this repo, simply create a new WordPress site on your local machine (using whatever development environment suits you), then empty out the `wp-content` folder and clone this repo into it. After logging in to the admin area activate `wporg-support` theme for the site to work.
 
 You can get more information about running the HelpHub code base locally via reading the [contributing document](https://github.com/WordPress/HelpHub/blob/master/CONTRIBUTING.md)
 ## Workflow


### PR DESCRIPTION
This PR corrects a small typo in the README file.

The setup instructions currently reference the theme slug `wprog-support`, which does not exist.  
The correct theme slug used on WordPress.org is `wporg-support`.

Updating this improves accuracy and prevents confusion for contributors setting up HelpHub locally.

No other files were modified.