### PR TITLE
Docs: Update project description and fix theme slug typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HelpHub
 
-[![Build Status](https://travis-ci.com/WordPress/HelpHub.svg?branch=master)](https://travis-ci.com/WordPress/HelpHub)
+<!-- Removed outdated Travis CI badge -->
 
 
 HelpHub is the central portal for all WordPress user documentation, replacing much of the content that previously lived in the WordPress Codex.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/WordPress/HelpHub.svg?branch=master)](https://travis-ci.com/WordPress/HelpHub)
 
 
-HelpHub is going to be the new portal for all WordPress user documentation that currently resides on the [WordPress Codex](https://codex.wordpress.org/). This repo is where we will be managing the development of this new portal.
+HelpHub is the central portal for all WordPress user documentation, replacing much of the content that previously lived in the WordPress Codex.
 
 ## Get Involved
 
@@ -11,7 +11,7 @@ You can get involved in development (or any other aspect of the project) by atte
 
 ## How to use this repo
 
-To use this repo, simply create a new WordPress site on your local machine (using whatever development environment suits you), then empty out the `wp-content` folder and clone this repo into it. After logging in to the admin area activate `wprog-support` theme for the site to work.
+To use this repo, simply create a new WordPress site on your local machine (using whatever development environment suits you), then empty out the `wp-content` folder and clone this repo into it. After logging in to the admin area activate `wporg-support` theme for the site to work.
 
 You can get more information about running the HelpHub code base locally via reading the [contributing document](https://github.com/WordPress/HelpHub/blob/master/CONTRIBUTING.md)
 ## Workflow


### PR DESCRIPTION
This PR updates the project description in the README to better reflect
HelpHub's current role as the central portal for WordPress user
documentation.

It also corrects a small typo in the theme activation instructions:
replacing `wprog-support` with the correct `wporg-support` theme slug.